### PR TITLE
Remove takt/herdr, vim/neovim, and unused emacs packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -254,25 +254,6 @@
         "type": "github"
       }
     },
-    "herdr": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "lastModified": 1783821372,
-        "narHash": "sha256-foqnazFkRve37QrMfgT2CKfzJcmhMpVwxPUJiKf6woE=",
-        "owner": "ogulcancelik",
-        "repo": "herdr",
-        "rev": "4ca6cac445a6aa45eb3b8462f66cd595d0c01364",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ogulcancelik",
-        "repo": "herdr",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -298,7 +279,7 @@
         "blueprint": "blueprint",
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       },
@@ -406,22 +387,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1783475452,
         "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
         "owner": "NixOS",
@@ -436,7 +401,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1783791668,
         "narHash": "sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA=",
@@ -452,7 +417,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1783279667,
         "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
@@ -468,26 +433,10 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1781454065,
-        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_4",
         "systems": "systems_2"
       },
       "locked": {
@@ -527,37 +476,13 @@
         "brew-nix": "brew-nix",
         "emacs-overlay": "emacs-overlay",
         "flake-parts": "flake-parts",
-        "herdr": "herdr",
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
         "nix-darwin": "nix-darwin",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "nixvim": "nixvim",
-        "org-babel": "org-babel",
-        "takt": "takt",
-        "vim-src": "vim-src"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "herdr",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1783577481,
-        "narHash": "sha256-EWMxOWrJ031f8f/lrcEmhTRs4npw1/5N3Hcjin846c8=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "4cdea398dc491b082dccdce0fad1ed0b75fa3394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "org-babel": "org-babel"
       }
     },
     "systems": {
@@ -591,24 +516,6 @@
         "type": "github"
       }
     },
-    "takt": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_6"
-      },
-      "locked": {
-        "lastModified": 1783813091,
-        "narHash": "sha256-FKHv8sEimrFGDLNqRuIvJZyqqIEFpzWXLRLEtO/A3vY=",
-        "owner": "nrslib",
-        "repo": "takt",
-        "rev": "104bade085c4a551c559d2e85fe37c0bf29f599a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nrslib",
-        "repo": "takt",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -627,22 +534,6 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "vim-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1783095897,
-        "narHash": "sha256-D4IyDgl1JdmumDzO0uMg2LhoSnFUeqhcMJ6ImC17wzs=",
-        "owner": "vim",
-        "repo": "vim",
-        "rev": "834b8d218f1db92e587ecd449e5ce88b41fbe256",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vim",
-        "repo": "vim",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    vim-src = {
-      url = "github:vim/vim";
-      flake = false;
-    };
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -36,8 +32,6 @@
     };
     llm-agents.url = "github:numtide/llm-agents.nix";
     arto.url = "github:arto-app/Arto";
-    takt.url = "github:nrslib/takt";
-    herdr.url = "github:ogulcancelik/herdr";
     agent-skills-nix = {
       url = "github:Kyure-A/agent-skills-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -60,8 +54,6 @@
     brew-nix,
     llm-agents,
     arto,
-    takt,
-    herdr,
     nixos-wsl,
     agent-skills-nix,
     ...
@@ -85,8 +77,6 @@
           brew-nix
           llm-agents
           arto
-          takt
-          herdr
           nixos-wsl
           ;
         system = darwinSystem;
@@ -103,8 +93,6 @@
           brew-nix
           llm-agents
           arto
-          takt
-          herdr
           nixos-wsl
           ;
         system = nixosSystem;

--- a/home-manager/claude-code/settings.json
+++ b/home-manager/claude-code/settings.json
@@ -22,16 +22,6 @@
           }
         ]
       }
-    ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo \"Claude Code: $(jq -r '.message')\" | terminal-notifier -title 'Claude Code'"
-          }
-        ]
-      }
     ]
   }
 }

--- a/home-manager/darwin.nix
+++ b/home-manager/darwin.nix
@@ -5,7 +5,7 @@ with pkgs; [
   # brewCasks.docker-desktop
   brewCasks.chatgpt
   # brewCasks.ollama-app
-  brewCasks.codex-app
+  brewCasks.codex
   # The claude desktop cask ships a `bin/claude` wrapper that collides with the
   # claude-code CLI's `bin/claude`. Lower its priority so the CLI wins the bin/
   # while the desktop .app bundle (a non-conflicting path) is still installed.

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -77,9 +77,6 @@
       kakehashi
       yaskkserv2
     ]
-    ++ lib.optionals pkgs.stdenv.isDarwin [
-      terminal-notifier
-    ]
     ++ lib.optionals (artoPkg != null) [
       artoPkg
     ]

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -10,8 +10,6 @@
   brew-nix,
   llm-agents,
   arto,
-  takt,
-  herdr,
   ...
 }: let
   pkgs = import nixpkgs {
@@ -31,8 +29,6 @@
     if pkgs.stdenv.isDarwin
     then arto.packages.${system}.default
     else null;
-  taktPkg = takt.packages.${system}.default;
-  herdrPkg = herdr.packages.${system}.default;
   # nodePkgs = pkgs.callPackage ../node2nix {inherit pkgs;};
   yaskkserv2 = pkgs.callPackage ./yaskkserv2 {inherit pkgs sources;};
   # mocword = pkgs.callPackage ./mocword {inherit pkgs sources;};
@@ -70,7 +66,6 @@
   basePackages = with pkgs;
     [
       # editor & other tools
-      vim
       tree-sitter
       # mocword
       cargo-compete
@@ -79,10 +74,6 @@
     ]
     ++ lib.optionals (artoPkg != null) [
       artoPkg
-    ]
-    ++ [
-      taktPkg
-      herdrPkg
     ];
 in {
   imports = [

--- a/home-manager/emacs/early-init.el
+++ b/home-manager/emacs/early-init.el
@@ -1,2 +1,0 @@
-(setq debug-on-error t)
-;;(setenv "LSP_USE_PLISTS" "true")

--- a/home-manager/emacs/epkgs.nix
+++ b/home-manager/emacs/epkgs.nix
@@ -27,10 +27,7 @@ in
     packages.nskk
     rainbow-delimiters
     major-mode-hydra
-    tempel
-    quickrun
     avy-zap
-    ellama
     yasnippet
     consult-yasnippet
     oj
@@ -43,7 +40,6 @@ in
     packages.dmacro
     packages.instant-maximized-window
     packages.nano-modeline
-    centered-cursor-mode
     packages.arto
     packages.ghostel
 
@@ -56,7 +52,6 @@ in
     marginalia
     avy
     consult
-    consult-flycheck
     embark
     embark-consult
     affe
@@ -69,7 +64,6 @@ in
     # langs
     auctex
     packages.yatex
-    ebib
     packages.typst-ts-mode
     python-mode
     pet
@@ -112,13 +106,11 @@ in
     org-superstar
     ox-gfm
     ox-typst
-    org-modern
     org-pomodoro
     svg-tag-mode
     ox-hugo
     org-roam
     org-roam-ui
-    consult-org-roam
     org-super-agenda
     org-appear
     org-journal

--- a/home-manager/emacs/init.org
+++ b/home-manager/emacs/init.org
@@ -407,7 +407,7 @@ binding))))))))
 #+begin_src emacs-lisp
 (require 'nerd-icons)
 (setq nerd-icons-font-family "Symbols Nerd Font Mono")
-; (add-hook 'emact-startup-hook #'nerd-icons-completion-mode)
+; (add-hook 'emacs-startup-hook #'nerd-icons-completion-mode)
 (nerd-icons-completion-mode)
 #+end_src
 
@@ -541,7 +541,7 @@ binding))))))))
         corfu-auto-delay 0.5
         corfu-cycle t
         corfu-auto-prefix 3
-        corfu-preselect 'prompt
+        corfu-preselect 'first
         corfu-on-exact-match nil
         corfu-quit-at-boundary 'separator
         corfu-quit-no-match 'separator
@@ -549,8 +549,765 @@ binding))))))))
         corfu-popupinfo-delay '(0.5 . 0.2))
   (keymap-set corfu-map "M-SPC" #'corfu-insert-separator)
   (keymap-set corfu-map "M-d" #'corfu-popupinfo-documentation)
-  (keymap-set corfu-map "M-l" #'corfu-popupinfo-location)
-  (keymap-set corfu-map "C-y" #'corfu-insert))
+  (keymap-set corfu-map "M-l" #'corfu-popupinfo-location))
+#+end_src
+
+*** ミニバッファ補完
+**** vertico
+#+begin_src emacs-lisp
+(savehist-mode)
+(require 'vertico)
+(add-hook 'emacs-startup-hook #'vertico-mode)
+(advice-add #'vertico--setup :after
+            (lambda (&rest _)
+              (setq-local completion-auto-help nil
+                          completion-show-inline-help nil)))
+#+end_src
+
+**** marginalia
+#+begin_src emacs-lisp
+(require 'marginalia)
+(add-hook 'emacs-startup-hook #'marginalia-mode)
+(add-hook 'marginalia-mode-hook #'nerd-icons-completion-marginalia-setup)
+#+end_src
+
+**** orderless
+#+begin_src emacs-lisp
+(require 'orderless)
+(with-eval-after-load 'minibuffer
+  ;; config
+  (add-to-list 'completion-styles-alist '(orderless orderless-try-completion orderless-all-completions
+                                                    "Completion of multiple components, in any order."))
+  (setopt completion-styles '(orderless initials flex basic))
+  (setopt completion-category-overrides '((file (styles flex basic partial-completion))
+                                          (eglot (styles orderless))
+                                          (eglot-capf (styles orderless)))))
+#+end_src
+
+** 補完ソース
+*** 補完バックエンド
+**** cape
+#+begin_src emacs-lisp
+;;(defvar completion-at-point-functions '(tags-completion-at-point-function))
+(require 'cape)
+;(add-to-list 'completion-at-point-functions #'cape-dabbrev)
+(add-to-list 'completion-at-point-functions #'cape-dict)
+(add-to-list 'completion-at-point-functions #'cape-file)
+(add-to-list 'completion-at-point-functions #'cape-history)
+(add-to-list 'completion-at-point-functions #'cape-elisp-block)
+(add-to-list 'completion-at-point-functions #'cape-tex)
+(add-to-list 'completion-at-point-functions #'cape-emoji)
+#+end_src
+
+*** スニペット
+**** yasnippet
+#+begin_src emacs-lisp
+(require 'yasnippet)
+(add-hook 'emacs-startup-hook #'yas-global-mode)
+(setq yas-prompt-functions '(yas-ido-prompt))
+;; pythonのインデントバグを修正する関数
+(defun yasnippet-snippets--fixed-indent ()
+  "Set `yas-indent-line' to `fixed'."
+  (set (make-local-variable 'yas-indent-line) 'fixed))
+(add-hook 'python-mode-hook #'yasnippet-snippets--fixed-indent)
+
+(require 'consult-yasnippet)
+(keymap-global-set "C-c y" #'consult-yasnippet)
+(keymap-global-set "C-c C-y" #'consult-yasnippet)
+#+end_src
+
+** 補完UI拡張
+*** アイコン表示
+**** nerd-icons-corfu
+#+begin_src emacs-lisp
+;;(add-to-list 'corfu-margin-formatters #'nerd-icons-corfu-formatter)
+#+end_src
+
+**** kind-icon
+#+begin_src emacs-lisp
+(require 'kind-icon)
+(setq kind-icon-default-face 'corfu-default
+      kind-icon-blend-background nil
+      kind-icon-blend-frac 0.08)
+(add-to-list 'corfu-margin-formatters #'kind-icon-margin-formatter)
+#+end_src
+
+* Git統合
+** Git操作
+*** 基本操作
+**** magit
+#+begin_src emacs-lisp
+(require 'magit)
+#+end_src
+
+*** 差分表示
+**** git-gutter
+#+begin_src emacs-lisp
+(require 'git-gutter)
+(add-hook 'emacs-startup-hook #'global-git-gutter-mode)
+#+end_src
+
+* Org-mode
+** Org基本機能
+*** コア機能
+**** org
+#+begin_src emacs-lisp
+(setq org-directory "~/ghq/github.com/keimoriyama/org-files")
+
+;; org-element のインクリメンタルキャッシュを無効化する。
+;; dashboard が after-init-hook で agenda を走査する際、複数ファイル+narrow
+;; の組み合わせでキャッシュが不整合になり
+;; "Invalid search bound (wrong side of point)" で起動が失敗することがある。
+;; 無効化すると org-scan-tags は走査ごとに新品のキャッシュを使い、この不整合を回避できる。
+(setq org-element-use-cache nil)
+
+(defun create-file (filename)
+  (if (not (file-exists-p filename))
+      (make-empty-file filename)))
+
+(defun create-new-org-file (path)
+  (let ((name (read-string "Name: ")))
+    (expand-file-name (format "%s.org"
+                              name) path)))
+
+(require 'org)
+(with-eval-after-load 'org
+  (setq org-startup-folded 'fold
+        org-deadline-warning-day  30
+        org-enforce-todo-dependencies t
+        org-html-htmlize-output-type 'css
+        org-adapt-indentation t
+        org-hide-leading-stars t
+        org-hide-emphasis-markers t
+        org-pretty-entities t
+        org-ellipsis "  ·"
+        org-src-fontify-natively t
+        org-src-tab-acts-natively t
+        org-edit-src-content-indentation 0
+        org-lowest-priority ?F
+        org-default-priority ?E
+        org-use-sub-superscripts '{}
+        org-export-with-sub-superscripts nil
+        org-priority-faces '((65 . "#BF616A")
+                             (66 . "#EBCB8B")
+                             (67 . "#B48EAD")
+                             (68 . "#81A1C1")
+                             (69 . "#5E81AC")
+                             (70 . "#4C566A"))
+        org-todo-keywords
+        '((sequence "TODO(t)" "NEXT(n)" "DOING(i)" "WAIT(w)" "PLANNING(p)" "|" "DONE(d)"))
+        org-todo-keyword-faces
+        '(("TODO"   :foreground "#A3BE8C" :weight bold)
+          ("DOING"  :foreground "#88C0D0" :weight bold)
+          ("NEXT"   :foreground "#88C0D0" :weight bold)
+          ("WAIT"   :foreground "#88C0D0" :weight bold)
+          ("DONE"   :foreground "#ff40ff" :weight bold)
+          ("PLANNING"   :foreground "#88C0D0" :weight bold))
+        org-tag-alist '(("lab" . ?l)
+                        ("ra" . ?r)
+                        ("paper" . ?p)
+                        ("task" . ?t)
+                        ("analysis" . ?a)
+                        ("bug" . ?b))
+        org-global-properties
+        '(("Effort_ALL" . "0 0:25 0:50 1:15 1:40")))
+
+  (add-hook 'org-mode-hook 'visual-line-mode)
+
+  (dolist (face '((org-level-1 . 1.35)
+                  (org-level-2 . 1.3)
+                  (org-level-3 . 1.2)
+                  (org-level-4 . 1.1)
+                  (org-level-5 . 1.1)
+                  (org-level-6 . 1.1)
+                  (org-level-7 . 1.1)
+                  (org-level-8 . 1.1)))
+    (set-face-attribute (car face) nil :height (cdr face)))
+  (setq org-src-fontify-natively t
+        org-src-tab-acts-natively t
+        org-edit-src-content-indentation 0)
+  (setq org-log-done 'time
+        org-auto-align-tags                t
+        org-tags-column                    -80
+        org-fold-catch-invisible-edits     'show-and-error
+        org-special-ctrl-a/e               t
+        org-insert-heading-respect-content t))
+#+end_src
+
+**** org-clock
+#+begin_src emacs-lisp
+(defun notify-osx (title message)
+  (call-process "osascript" nil 0 nil
+                "-e" (format "display notification %S with title %S"
+                             message title)))
+(add-hook 'org-clock-in-hook
+          (lambda ()
+            (notify-osx "Clock Started" "Working....")))
+(add-hook 'org-clock-out-hook
+          (lambda ()
+            (notify-osx "Clock Finished" "DONE!!!!")))
+#+end_src
+** Org拡張機能
+*** キャプチャ・ノート機能
+**** org-capture-programming-notes
+#+begin_src emacs-lisp
+(setq org-memo-file (format "%s/memo.org" org-directory)
+      org-project-file (format "%s/projects/project.org" org-directory)
+      org-exp-file (format "%s/exp.org" org-directory)
+      org-prj-dir (format "%s/projects" org-directory)
+      org-journal-dir (format "%s/journal" org-directory)
+      org-program-dir (format "%s/programming" org-directory))
+
+(defvar my/org-roam-programming-languages
+  '(("p" "Python"      "python.org"      "python")
+    ("e" "Emacs Lisp" "emacs-lisp.org"  "emacs-lisp")
+    ("r" "Rust"       "rust.org"        "rust"))
+  "Programming language capture targets.
+
+Each entry is:
+  (KEY TITLE FILENAME SRC-LANG)")
+
+
+(defun my/org-roam-programming-template (spec)
+  "Create one org-roam-capture template from SPEC.
+
+SPEC is:
+  (KEY TITLE FILENAME SRC-LANG)"
+  (pcase-let ((`(,key ,title ,filename ,src-lang) spec))
+    `(,(concat "p" key)
+      ,title
+      plain
+      ,(format
+        "** %%?\n:PROPERTIES:\n:ID: %%(org-id-new)\n:END:\nCaptured: %%U\n\n#+begin_src %s\n%%i\n#+end_src\n"
+        src-lang)
+      :target
+      (file+olp+head
+       ,(format "programming/%s" filename)
+       ("Notes")
+       ,(format "#+title: %s\n#+filetags: :programming:%s:\n\n* Notes\n"
+                title src-lang))
+      :unnarrowed t)))
+(defun my/org-programming-capture-template (spec)
+
+  "Create one org-capture template from SPEC.
+
+SPEC is:
+
+  (KEY TITLE FILENAME SRC-LANG)"
+
+  (pcase-let ((`(,key ,title ,filename ,src-lang) spec))
+
+    `(,(concat "p" key)
+
+      ,title
+
+      entry
+
+      (file+headline
+
+       ,(format "%s/%s" org-program-dir filename)
+
+       "Notes")
+
+      ,(format
+
+        "* %%?\n:PROPERTIES:\n:ID: %%(org-id-new)\n:END:\nCaptured: %%U\n\n#+begin_src %s\n%%i\n#+end_src\n"
+
+        src-lang)
+
+      :empty-lines 1)))
+
+(defvar my/org-roam-programming-capture-templates
+  (append
+   '(("p" "Programming"))
+   (mapcar #'my/org-programming-capture-template
+           my/org-roam-programming-languages))
+  "Org-roam capture templates for programming language notes.")
+#+end_src
+**** org-capture
+#+begin_src emacs-lisp
+(mapc #'create-file
+      (list org-memo-file))
+
+(with-eval-after-load 'org
+  (setq org-capture-templates
+        (append
+         '(("m" "Memo" entry (file org-memo-file) " %? \n"))
+         my/org-roam-programming-capture-templates))
+  (keymap-global-set "C-c c" #'org-capture))
+#+end_src
+**** org-journal
+#+begin_src emacs-lisp
+(require 'org-journal)
+(setq org-journal-file-type 'daily)
+(setq org-journal-start-on-weekday 3)
+(setq org-journal-file-format "%Y%m%d.org")
+(keymap-global-set "C-c j" #'org-journal-new-entry)
+#+end_src
+**** org-roam (基本設定)
+#+begin_src emacs-lisp
+(require 'org-roam)
+(setq org-roam-db-update-method 'immediate
+      org-roam-db-location (format "%s/org-roam.db" org-directory)
+      org-roam-directory org-directory
+      org-roam-index-file (format "%s/index.org" org-directory))
+(org-roam-db-autosync-mode)
+(keymap-global-set "C-c n f" #'org-roam-node-find)
+(keymap-global-set "C-c n i" #'org-roam-node-insert)
+(keymap-global-set "C-c n t" #'org-roam-tag-add)
+(keymap-global-set "C-c n a" #'org-roam-alias-add)
+(keymap-global-set "C-c n c" #'org-roam-capture)
+;; (keymap-global-set "C-c n j" #'org-roam-dailies-capture-today)
+;; (keymap-global-set "C-c n d" #'org-roam-dailies-goto-today)
+(with-eval-after-load 'org-roam-node
+  (setq org-roam-completion-everywhere nil))
+#+end_src
+
+**** org-roam-db
+#+begin_src emacs-lisp
+(require 'org-roam-db)
+(with-eval-after-load 'org-roam-db
+  (setq org-roam-database-connector 'sqlite)
+  (setq org-roam-db-gc-threshold (* 4 gc-cons-threshold)))
+#+end_src
+
+**** org-roam-capture-template
+#+begin_src emacs-lisp
+(require 'org-roam-capture)
+(with-eval-after-load 'org-roam-capture
+  (setopt org-roam-capture-templates
+           '(
+             ("f" "Fleeting" plain "%?"
+              :target (file+head
+                       "fleeting/%<%Y%m%d%H%M%S>-${slug}.org"
+                       "#+title: ${title}\n")
+              :unnarrowed t)
+             ("p" "Projects" plain "%?"
+              :target (file+head
+                       "projects/${slug}.org"
+                       "#+title: ${title}\n")
+              :unnarrowed t)
+             ("l" "Literature" plain "%?"
+              :target (file+head
+                       "literatures/%<%Y%m%d%H%M%S>-${slug}.org"
+                       "#+title: ${title}\n")
+              :unnarrowed t)
+             ("b" "books" plain "%?"
+              :target (file+head
+                       "books/%<%Y%m%d%H%M%S>-${slug}.org"
+                       "#+title: ${title}\n")
+              :unnarrowed t)
+             ("P" "parmanent" plain "%?"
+              :target (file+head
+                       "parmanent/%<%Y%m%d%H%M%S>-${slug}.org"
+                       "#+title: ${title}\n")
+              :unnarrowed t))))
+#+end_src
+
+**** org-roam-ui
+#+begin_src emacs-lisp
+(require 'org-roam-ui)
+#+end_src
+*** 外観・表示機能
+**** org-indent
+#+begin_src emacs-lisp
+(require 'org-indent)
+(add-hook 'org-mode-hook #'org-indent-mode)
+
+(set-face-attribute 'org-indent nil :inherit '(org-hide fixed-pitch))
+(set-face-attribute 'org-block nil            :foreground nil :inherit
+                    'fixed-pitch :height 1.0)
+(set-face-attribute 'org-code nil             :inherit '(shadow fixed-pitch) :height 0.85)
+(set-face-attribute 'org-indent nil           :inherit '(org-hide fixed-pitch) :height 0.85)
+(set-face-attribute 'org-verbatim nil         :inherit '(shadow fixed-pitch) :height 0.85)
+(set-face-attribute 'org-special-keyword nil  :inherit '(font-lock-comment-face
+                                                         fixed-pitch))
+(set-face-attribute 'org-meta-line nil        :inherit '(font-lock-comment-face fixed-pitch))
+(set-face-attribute 'org-checkbox nil         :inherit 'fixed-pitch)
+(add-hook 'org-mode-hook 'variable-pitch-mode)
+(plist-put org-format-latex-options :scale 2)
+#+end_src
+
+**** org-superstar
+#+begin_src emacs-lisp
+(require 'org-superstar)
+(add-hook 'org-mode-hook #'org-superstar-mode)
+(with-eval-after-load 'org-superstar
+  (setq org-hide-leading-stars nil)
+  (setq org-superstar-headline-bullets-list '("◉" "○" "⚬" "◈" "◇"))
+  (setq org-superstar-leading-bullet "")
+  (setq org-superstar-special-todo-items t)
+  (setq org-superstar-todo-bullet-alist
+        '(("TODO"  . 9744)
+          ("WAIT"  . 9744)
+          ("DOING" . 9744)
+          ("NEXT"  . 9744)
+          ("DONE"  . 9745)
+          ("PLANNING"  . 9744))))
+#+end_src
+
+**** org-appear
+#+begin_src emacs-lisp
+(add-hook 'org-mode-hook #'org-appear-mode)
+(setq org-hide-emphasis-markers t)
+(setq org-appear-autoemphasis   t
+        org-appear-autolinks      t
+        org-appear-autosubmarkers t)
+#+end_src
+
+**** SVG Elements
+#+begin_src emacs-lisp
+(defconst date-re "[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}")
+(defconst time-re "[0-9]\\{2\\}:[0-9]\\{2\\}")
+(defconst day-re "[A-Za-z]\\{3\\}")
+(defconst day-time-re (format "\\(%s\\)? ?\\(%s\\)?" day-re time-re))
+
+(defun svg-progress-percent (value)
+  (svg-image (svg-lib-concat
+              (svg-lib-progress-bar (/ (string-to-number value) 100.0)
+                nil :margin 0 :stroke 2 :radius 3 :padding 2 :width 11)
+              (svg-lib-tag (concat value "%")
+                nil :stroke 0 :margin 0)) :ascent 'center))
+
+(defun svg-progress-count (value)
+  (let* ((seq (mapcar #'string-to-number (split-string value "/")))
+         (count (float (car seq)))
+         (total (float (cadr seq))))
+    (svg-image (svg-lib-concat
+                 (svg-lib-progress-bar (/ count total) nil
+                   :margin 0 :stroke 2 :radius 3 :padding 2 :width 11)
+                 (svg-lib-tag value nil
+                   :stroke 0 :margin 0)) :ascent 'center)))
+(setq svg-tag-tags
+    `(
+      ;; Task priority
+      ("\\[#[A-Z]\\]" . ( (lambda (tag)
+                            (svg-tag-make tag :face 'org-priority
+                                          :beg 2 :end -1 :margin 0))))
+
+      ;; Progress
+      ("\\(\\[[0-9]\\{1,3\\}%\\]\\)" . ((lambda (tag)
+        (svg-progress-percent (substring tag 1 -2)))))
+      ("\\(\\[[0-9]+/[0-9]+\\]\\)" . ((lambda (tag)
+        (svg-progress-count (substring tag 1 -1)))))
+
+      ;; Active date (with or without day name, with or without time)
+      (,(format "\\(<%s>\\)" date-re) .
+       ((lambda (tag)
+          (svg-tag-make tag :beg 1 :end -1 :margin 0))))
+      (,(format "\\(<%s \\)%s>" date-re day-time-re) .
+       ((lambda (tag)
+          (svg-tag-make tag :beg 1 :inverse nil :crop-right t :margin 0))))
+      (,(format "<%s \\(%s>\\)" date-re day-time-re) .
+       ((lambda (tag)
+          (svg-tag-make tag :end -1 :inverse t :crop-left t :margin 0))))
+
+      ;; Inactive date  (with or without day name, with or without time)
+       (,(format "\\(\\[%s\\]\\)" date-re) .
+        ((lambda (tag)
+           (svg-tag-make tag :beg 1 :end -1 :margin 0 :face 'org-date))))
+       (,(format "\\(\\[%s \\)%s\\]" date-re day-time-re) .
+        ((lambda (tag)
+           (svg-tag-make tag :beg 1 :inverse nil
+                          :crop-right t :margin 0 :face 'org-date))))
+       (,(format "\\[%s \\(%s\\]\\)" date-re day-time-re) .
+        ((lambda (tag)
+           (svg-tag-make tag :end -1 :inverse t
+                          :crop-left t :margin 0 :face 'org-date))))))
+
+(add-hook 'org-mode-hook 'svg-tag-mode)
+#+end_src
+
+**** Prettify Tags & Keywords
+#+begin_src emacs-lisp
+(defun my/prettify-symbols-setup ()
+  ;; Checkboxes
+  (push '("[ ]" . "☐") prettify-symbols-alist)
+  (push '("[X]" . "☑") prettify-symbols-alist)
+  (push '("[-]" . "❍" ) prettify-symbols-alist)
+
+  ;; org-babel
+  (push '("#+BEGIN_SRC" . ?≫) prettify-symbols-alist)
+  (push '("#+END_SRC" . ?≫) prettify-symbols-alist)
+  (push '("#+begin_src" . ?≫) prettify-symbols-alist)
+  (push '("#+end_src" . ?≫) prettify-symbols-alist)
+
+  (push '("#+begin_quote" . ?❝) prettify-symbols-alist)
+  (push '("#+end_quote" . ?❞) prettify-symbols-alist)
+
+  ;; Drawers
+  (push '(":PROPERTIES:" . ?≫) prettify-symbols-alist)
+
+  (push '("SCHEDULED:" . ?🕘) prettify-symbols-alist)
+  (push '("DEADLINE:" . ?⏰) prettify-symbols-alist)
+  (push '("CLOCK:" . ?⌚) prettify-symbols-alist)
+  (push '("CLOSED:" . ?✅) prettify-symbols-alist)
+
+  ;; Tags
+  (push '(":PROPERTIES:" . ?≫) prettify-symbols-alist)
+  (push '(":LOGBOOK:" . ?≫) prettify-symbols-alist)
+  (push '(":END:" . ?≫) prettify-symbols-alist)
+  (push '(":projects:" . ?🚀) prettify-symbols-alist)
+  (push '(":task:"     . ?✅) prettify-symbols-alist)
+  (push '(":paper:"   . ?📝) prettify-symbols-alist)
+  (push '(":lab:"   . ?🥼) prettify-symbols-alist)
+  (push '(":ra:"   . ?📖) prettify-symbols-alist)
+  (push '(":bug:"   . ?🐛) prettify-symbols-alist)
+  (push '(":analysis:" . ?📈) prettify-symbols-alist)
+  (prettify-symbols-mode))
+
+(add-hook 'org-mode-hook        #'my/prettify-symbols-setup)
+(add-hook 'org-agenda-mode-hook #'my/prettify-symbols-setup)
+#+end_src
+
+*** カレンダー設定
+**** calendar
+#+begin_src emacs-lisp
+(with-eval-after-load 'calendar
+  ;; 曜日を日本語で表示（全角文字の表示幅を考慮）
+  (setq calendar-day-header-array ["日" "月" "火" "水" "木" "金" "土"])
+  ;; 曜日の完全名も日本語で設定
+  (setq calendar-day-name-array
+        ["日曜日" "月曜日" "火曜日" "水曜日" "木曜日" "金曜日" "土曜日"])
+  ;; 曜日の省略名を日本語で設定
+  (setq calendar-day-abbrev-array ["日" "月" "火" "水" "木" "金" "土"])
+  ;; 月名を日本語で表示
+  (setq calendar-month-name-array
+        ["1月" "2月" "3月" "4月" "5月" "6月"
+         "7月" "8月" "9月" "10月" "11月" "12月"])
+  ;; 週の開始を日曜日にする（0=日曜日、1=月曜日）
+  (setq calendar-week-start-day 0)
+  ;; 月/日/年の順番で表示
+  (setq calendar-date-style 'iso)
+  ;; 月間カレンダーの左側の余白を調整
+  (setq calendar-left-margin 5)
+  ;; 月と月の間の余白
+  (setq calendar-intermonth-spacing 4)
+  ;; 曜日ヘッダーとカレンダー本体の間の余白
+  (setq calendar-column-width 3))
+#+end_src
+*** コード実行・エクスポート機能
+**** org-babel
+#+begin_src emacs-lisp
+(org-babel-do-load-languages
+'org-babel-load-languages
+'((python . t)
+  (shell . t)
+  (rust . t)
+  (haskell . t)))
+
+(setq org-babel-python-command "../.venv/bin/python")
+(require 'ob-core)
+(with-eval-after-load 'ob-core
+  (setopt org-confirm-babel-evaluate nil)
+  (setopt org-babel-default-header-args '((:session . "none")
+                                          (:results . "drawer replace")
+                                          (:exports . "code")
+                                          (:cache . "no")
+                                          (:noweb . "no")
+                                          (:hlines . "no")
+                                          (:tangle . "no"))))
+(with-eval-after-load 'ob-lisp
+  (defalias 'org-babel-execute:common-lisp 'org-babel-execute:lisp)
+  (setq org-id-locations-file
+      (expand-file-name "org-id-locations" user-emacs-directory)))
+#+end_src
+
+**** org-super-agenda
+#+begin_src emacs-lisp
+(require 'org-super-agenda)
+(org-super-agenda-mode t)
+#+end_src
+
+**** org-agenda
+#+begin_src emacs-lisp
+(require 'org-agenda)
+
+(with-eval-after-load 'org
+  (setq org-agenda-custom-commands
+        '(("x" "Unscheduled Tasks" tags-todo
+           "-SCHEDULED>=\"<today>\"-DEADLINE>=\"<today>\"" nil)
+          ("v" "List of TODOs"
+           ((agenda "" ((org-agenda-span 'day)
+                        (org-super-agenda-groups
+                         '((:name "Today"
+                                  :time-grid t
+                                  :date today
+                                  :scheduled today)))))
+            (alltodo "" ((org-agenda-overriding-header "")
+                         (org-super-agenda-groups
+                          '((:name "Important"
+                                   :priority "A"
+                                   :order 1)
+                            (:name "Doing"
+                                   :todo "DOING"
+                                   :order 2)
+                            (:name "Next Todo"
+                                   :todo "NEXT"
+                                   :order 3)
+                            (:name "Due Today"
+                                   :deadline today
+                                   :order 4)
+                            (:name "Due Soon"
+                                   :deadline future
+                                   :order 5)
+                            (:name "Wait"
+                                   :todo "WAIT"
+                                   :order 6)
+                            (:name "Overdue"
+                                   :deadline past
+                                   :order 7)
+                            (:name "Todo"
+                                   :todo "TODO"
+                                   :order 8)
+                            (:name "Paper"
+                                   :tag "paper"
+                                   :order 1000)
+                            (:discard (:anything t))))))))))
+
+  (setq org-agenda-start-on-weekday 3
+        org-agenda-span 'week
+        org-agenda-skip-scheduled-if-done t
+        org-agenda-skip-deadline-if-done t
+        org-agenda-include-deadlines t
+        org-return-follows-link t
+        org-agenda-time-grid
+        '((daily today require-timed)
+          (0900 1200 1300 1800) "......" "----------------")
+        org-columns-default-format
+        "%68ITEM(Task) %6Effort(Effort){:} %6CLOCKSUM(Clock){:}"
+        org-clock-out-remove-zero-time-clocks t
+        org-agenda-use-time-grid t
+        org-clock-clocked-in-display 'both
+        org-agenda-start-with-log-mode t
+        org-agenda-files (list org-prj-dir org-journal-dir)
+        org-agenda-archives-mode t))
+(plist-put org-format-latex-options :scale 1.2)
+(keymap-global-set "C-c a" #'org-agenda)
+#+end_src
+
+**** org-pomodoro
+#+begin_src emacs-lisp
+(require 'org-pomodoro)
+(keymap-global-set "M-p" #'org-pomodoro)
+(with-eval-after-load 'org-pomodoro
+  (setopt org-pomodoro-play-sounds nil)
+  (setopt org-pomodoro-finished-sound-p nil)
+  (setopt org-pomodoro-short-break-sound-p nil)
+  (setopt org-pomodoro-long-break-sound-p nil)
+  (setopt org-pomodoro-manual-break nil)
+  (setopt org-pomodoro-format "Working %s")
+  (setopt org-pomodoro-length 25)
+  (setopt org-pomodoro-short-break-length 5)
+  (setq org-pomodoro-keep-killed-pomodoro-time t)
+
+  (defun org-pomodoro-kill ()
+    "Kill the current timer, reset the phase and update the modeline."
+    (interactive)
+    (org-clock-out)
+    (org-pomodoro-killed))
+
+  ;; org-pomodoro mode hooks
+  (add-hook 'org-pomodoro-finished-hook
+            (lambda ()
+              (notify-osx "Pomodoro completed!" "Time for a break.☕")))
+
+  (add-hook 'org-pomodoro-break-finished-hook
+            (lambda ()
+              (notify-osx "Pomodoro Short Break Finished" "Ready for Another?📝")))
+
+  (add-hook 'org-pomodoro-started-hook
+            (lambda ()
+              (notify-osx "Pomodoro Started! " "GO!🏃GO!🏃GO!🏃")))
+
+  (add-hook 'org-pomodoro-killed-hook
+            (lambda ()
+              (notify-osx "Pomodoro Killed" "One does not simply kill a pomodoro!🔪"))))
+#+end_src
+
+**** エクスポート設定
+***** ox-gfm
+#+begin_src emacs-lisp
+(require 'ox-gfm)
+#+end_src
+
+***** ox-hugo
+#+begin_src emacs-lisp
+(require 'ox-hugo)
+#+end_src
+
+***** ox-typst
+#+begin_src emacs-lisp
+(require 'ox-typst)
+#+end_src
+
+*** Org操作メニュー
+**** org-hydra
+#+begin_src emacs-lisp
+(defun my:org-goto-project ()
+    (interactive)
+    (find-file org-project-file))
+(defun my:org-goto-memo ()
+    (interactive)
+    (find-file org-memo-file))
+(defun my:org-goto-exp ()
+    (interactive)
+    (find-file org-exp-file))
+
+
+(major-mode-hydra-define org-mode
+  (:title "org mode" :color blue :quit-key "q" :foreign-keys warn :separator "╌")
+  ("visit file"
+   (("m" my:org-goto-memo "memo"))
+   "agenda"
+   (("a" org-agenda "agenda")
+    ("c" org-capture "capture"))
+   "insert"
+   (("h" org-insert-heading "header")
+    ("l" org-insert-link "link")
+    ("t" org-table-create "table"))
+   "export"
+   (("H" org-hugo-export-to-md "hugo md")
+    ("d" org-export-dispatch "dispatch"))
+   "move"
+   (("n" org-move-subtree-down "down" :exit nil)
+    ("u" org-move-subtree-up "up" :exit nil))))
+#+end_src
+**** hide-lines
+#+begin_src emacs-lisp
+(defun hide-done-tasks ()
+  (interactive)
+  (hide-lines-matching "* DONE"))
+
+(defun show-done-tasks ()
+  (interactive)
+  (hide-lines-show-all))
+#+end_src
+*** Export Command
+#+begin_src emacs-lisp
+(require 'ox-icalendar)
+(setq org-export-with-broken-links t)
+(setq org-agenda-default-appointment-duration 15)
+(setq org-icalendar-combined-agenda-file
+      (concat
+       (string-trim
+        (shell-command-to-string "ghq root"))
+       "/github.com/keimoriyama/org-files/calendar.ics"))
+;;; define categories that should be excluded
+(setq org-export-exclude-category (list "google" "private"))
+
+
+(setq org-icalendar-use-scheduled '(event-if-todo event-if-not-todo))
+(setq org-icalendar-use-deadline '(todo-due event-if-todo-not-done event-if-todo event-if-not-todo))
+
+;;; activate filter and call export function
+(defun org-mycal-export ()
+  (interactive)
+  (let ((org-id-locations-file
+         (expand-file-name ".org-id-locations" user-emacs-directory)))
+    (org-icalendar-combine-agenda-files)))
+  ;; (let ((org-icalendar-verify-function 'org-mycal-export-limit))
+  ;;   (org-icalendar-combine-agenda-files)))
 #+end_src
 
 #+RESULTS:
@@ -872,7 +1629,7 @@ org-mycal-export
   (("r" rust-run "run")
    ("c" rust-compile "compile")
    ("t" rust-test "test")
-   ("c" rust-check "check"))))
+   ("k" rust-check "check"))))
 #+end_src
 
 *** python-mode
@@ -1106,7 +1863,7 @@ org-mycal-export
 *** reftex
 #+begin_src emacs-lisp
 (require 'reftex)
-(add-to-list 'yatex-mode-hook #'reftex-mode)
+(add-hook 'yatex-mode-hook #'reftex-mode)
 (add-hook 'reftex-mode-hook '(lambda()
                                (setq reftex-default-bibliography
                                      (let ((root (projectile-project-root)))

--- a/home-manager/emacs/init.org
+++ b/home-manager/emacs/init.org
@@ -549,7 +549,8 @@ binding))))))))
         corfu-popupinfo-delay '(0.5 . 0.2))
   (keymap-set corfu-map "M-SPC" #'corfu-insert-separator)
   (keymap-set corfu-map "M-d" #'corfu-popupinfo-documentation)
-  (keymap-set corfu-map "M-l" #'corfu-popupinfo-location))
+  (keymap-set corfu-map "M-l" #'corfu-popupinfo-location)
+  (keymap-set corfu-map "C-y" #'corfu-insert))
 #+end_src
 
 *** ミニバッファ補完
@@ -1460,10 +1461,10 @@ org-mycal-export
 #+end_src
 ***** Latex
 #+begin_src emacs-lisp
-(add-hook 'yatex-mode-hook #'eglot-ensure)
-(with-eval-after-load 'eglot
-  (add-to-list 'eglot-server-programs
-               '((yatex-mode bibtex-mode) . ("texlab"))))
+;; (add-hook 'yatex-mode-hook #'eglot-ensure)
+;; (with-eval-after-load 'eglot
+;;   (add-to-list 'eglot-server-programs
+;;                '((yatex-mode bibtex-mode) . ("texlab"))))
 #+end_src
 ** flycheck
 #+begin_src emacs-lisp
@@ -1931,6 +1932,7 @@ org-mycal-export
 (setq nskk-debug-enabled t)
 (setq nskk-server-report-response t)
 (setq nskk-dict-user-dictionary-file skk-user-dict-path)
+(setq nskk-global-mode t)
 (require 'nskk-debug)
 #+end_src
 
@@ -1947,31 +1949,31 @@ org-mycal-export
 
 ** llm
 #+begin_src emacs-lisp
-(require 'llm)
-(require 'llm-ollama)
-(with-eval-after-load 'llm
-  (setopt llm-warn-on-nonfree nil))
+;; (require 'llm)
+;; (require 'llm-ollama)
+;; (with-eval-after-load 'llm
+;;   (setopt llm-warn-on-nonfree nil))
 #+end_src
 
 ** ellama
 #+begin_src emacs-lisp
-(require 'ellama)
-(require 'ellama-transient)
-(keymap-global-set "C-c e" #'ellama-transient-main-menu)
+;; (require 'ellama)
+;; (require 'ellama-transient)
+;; (keymap-global-set "C-c e" #'ellama-transient-main-menu)
 
-(with-eval-after-load 'ellama
-  (setopt ellama-language "日本語")
-  (let ((gemma2 (make-llm-ollama :chat-model "gemma2:9b" :embedding-model "gemma2:9b"))
-        (codellama (make-llm-ollama :chat-model "codellama:latest" :embedding-model "codellama:latest"))
-        (llama3 (make-llm-ollama :chat-model "llama3:8b" :embedding-model "llama3:8b")))
-    (setopt ellama-provider gemma2)
-    (setopt ellama-translation-provider gemma2)
-    (setopt ellama-summarization-provider llama3)
-    (setopt ellama-coding-provider codellama)
-    (setopt ellama-providers
-            `(("gemma2" . ,gemma2)
-              ("codellama" . ,codellama)
-              ("llama3" . ,llama3)))))
+;; (with-eval-after-load 'ellama
+;;   (setopt ellama-language "日本語")
+;;   (let ((gemma2 (make-llm-ollama :chat-model "gemma2:9b" :embedding-model "gemma2:9b"))
+;;         (codellama (make-llm-ollama :chat-model "codellama:latest" :embedding-model "codellama:latest"))
+;;         (llama3 (make-llm-ollama :chat-model "llama3:8b" :embedding-model "llama3:8b")))
+;;     (setopt ellama-provider gemma2)
+;;     (setopt ellama-translation-provider gemma2)
+;;     (setopt ellama-summarization-provider llama3)
+;;     (setopt ellama-coding-provider codellama)
+;;     (setopt ellama-providers
+;;             `(("gemma2" . ,gemma2)
+;;               ("codellama" . ,codellama)
+;;               ("llama3" . ,llama3)))))
 #+end_src
 
 ** Copilot

--- a/home-manager/langs.nix
+++ b/home-manager/langs.nix
@@ -5,7 +5,7 @@ with pkgs; [
   typescript
   lua
   typst
-  texliveFull
+  texliveBasic
   go
   ghc
   auctex

--- a/hosts/nixos-wsl/default.nix
+++ b/hosts/nixos-wsl/default.nix
@@ -49,7 +49,6 @@
     wget
     curl
     git
-    vim
     htop
   ];
 


### PR DESCRIPTION
## What changed

**Package cleanup** (`098f0f35`)
- Removed the `takt` and `herdr` flake inputs and all their references (params, `taktPkg`/`herdrPkg` bindings, `basePackages` entries).
- Removed standalone `vim` and the unused `vim-src` input — `nvim` now comes solely from **nixvim**. Also dropped `vim` from the nixos-wsl system packages.
- Pruned unused emacs packages from `epkgs.nix`: `tempel`, `quickrun`, `centered-cursor-mode`, `consult-flycheck`, `ebib`, `org-modern`, `consult-org-roam`, plus a duplicate `ellama` entry.
- Regenerated `flake.lock` to drop the removed inputs and their transitive deps.

**Emacs config tweaks** (`eba686c1`)
- Commented out `llm` and `ellama` (ollama) setup.
- Commented out the texlab eglot hook for `yatex-mode`.
- Added `C-y` → `corfu-insert` binding and enabled `nskk-global-mode`.

## Notes for reviewers
- `auctex` was initially removed as "unused" but restored — YaTeX relies on AUCTeX facilities (`reftex`/`bibtex`) that don't reference the `auctex` name directly.
- `ob-rust` and `ssh-config-mode` were kept despite no explicit config: `ob-rust` is loaded implicitly via the org-babel `(rust . t)` block, and `ssh-config-mode` autoloads for `~/.ssh/config`.
- This branch also carries 3 pre-existing local commits that were not yet on `origin/master` (`632c8045`, `9d7518f0`, `acbdf88c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)